### PR TITLE
Docker로 MySQL, Redis 환경 설정

### DIFF
--- a/coupon-core/src/main/resources/application-core.yml
+++ b/coupon-core/src/main/resources/application-core.yml
@@ -1,0 +1,27 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    hikari:
+      jdbc-url: jdbc:mysql://localhost:3306/coupon?useUnicode=yes&characterEncoding=UTF-8&rewriteBatchedStatements=true
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      maximum-pool-size: 10
+      max-lifetime: 30000
+      connection-timeout: 3000
+      username: root
+      password: root
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6380

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  redis:
+    container_name: coupon-redis
+    image: redis:7.2.4-alpine
+    command: ["redis-server", "--port", "6380"]
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - "6380:6380"
+
+  mysql:
+    container_name: coupon-mysql
+    image: mysql:8.3.0
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --explicit_defaults_for_timestamp=1
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: coupon
+      MYSQL_ROOT_PASSWORD: root
+      TZ: UTC
+    volumes:
+      - ./mysql/init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## PR 제목

feat: docker-compose 및 local 설정 파일 추가

## 개요

개발 환경 구성을 위한 docker-compose.yml 추가 및 application-core.yml에 local 프로필 설정을 적용했습니다.

## 주요 변경 사항

docker-compose.yml 추가
 * Redis:7.2.4-alpine 이미지 사용, 포트 6380 노출
 * MySQL:8.3.0 이미지 사용, coupon DB 초기화 및 UTF-8 설정
 * 초기화 스크립트는 ./mysql/init 경로에서 자동 실행
 * application-core.yml에 local 프로필 추가
 * Hikari 커넥션 풀 및 datasource 설정 (root/root, 3306 포트 기준)
 * JPA SQL 로그 출력 및 DDL 자동 생성 미사용 설정
 * Redis 설정 (localhost:6380)

## 테스트 및 검증
 * docker-compose up 명령어로 Redis, MySQL 정상 기동 확인
 * 로컬에서 local 프로필로 실행 시 DB 및 Redis 연결 성공 확인
 * MySQL 초기 스키마 자동 적용 여부 확인

## 기타 사항
 * DB 초기화 스크립트는 ./mysql/init 하위에 위치해야 합니다
 * application-core.yml에 spring.config.activate.on-profile: local로 명시된 설정임
 
 * * *

This closes #3 