### PR TITLE
부하 테스트 설정

### DIFF
--- a/coupon-api/src/main/java/com/laphayen/couponapi/controller/TestController.java
+++ b/coupon-api/src/main/java/com/laphayen/couponapi/controller/TestController.java
@@ -1,0 +1,15 @@
+package com.laphayen.couponapi.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/test")
+    public String test() {
+        return "test";
+    }
+
+
+}

--- a/load-test/docker-compose.yml
+++ b/load-test/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  locust-master:
+    container_name: locust-master
+    image: locustio/locust
+    ports:
+      - "8089:8089"
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --master
+      -H http://host.docker.internal:8080
+
+  locust-worker:
+    container_name: locust-worker
+    image: locustio/locust
+    depends_on:
+      - locust-master
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --worker
+      --master-host locust-master

--- a/load-test/docker-compose.yml
+++ b/load-test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   locust-master:
     container_name: locust-master
@@ -14,7 +12,6 @@ services:
       -H http://host.docker.internal:8080
 
   locust-worker:
-    container_name: locust-worker
     image: locustio/locust
     depends_on:
       - locust-master

--- a/load-test/locustfile-test.py
+++ b/load-test/locustfile-test.py
@@ -1,0 +1,11 @@
+from locust import task, FastHttpUser, stats
+
+stats.PERCENTILES_TO_CHART = [0.95, 0.99]
+
+class Test(FastHttpUser):
+    connection_timeout = 10.0
+    network_timeout = 10.0
+
+    @task
+    def test(self):
+        response = self.client.get("/test")


### PR DESCRIPTION
## PR 제목

chore: Locust 성능 테스트 환경 및 시나리오 추가

## 개요

부하 테스트를 위한 Locust 환경을 도커 기반으로 구성하고, 테스트 시나리오 및 확인용 API를 추가했습니다.

## 주요 변경 사항

* load-test/docker-compose.yml 작성
* locust-master: 8089 포트 노출, host.docker.internal:8080 대상으로 테스트 수행
* locust-worker: --worker 모드로 실행되며 다중 스케일링 가능 (container_name 제거)
* locustfile-test.py 시나리오 작성
* FastHttpUser 기반
* /test API를 주기적으로 호출
* 타임아웃: 10초, 퍼센타일 차트: 95%, 99%
* TestController 추가
* GET /test: “test” 문자열 반환 (성능 테스트 및 상태 확인용)

## 테스트 및 검증
* docker-compose up으로 master/worker 부하 테스트 구성 기동 확인
* http://localhost:8089 접속 후 테스트 실행 정상 동작
* /test API 호출 시 정상 응답 확인 ("test" 반환)

## 기타 사항
* locust-worker는 다중 인스턴스 지원을 위해 container_name을 제거했습니다
* 테스트 대상 서버 주소는 host.docker.internal 기준으로 설정됨 (로컬 실행용)

* * * 

This closes #5 