### PR TITLE
쿠폰 도메인 설계

### DIFF
--- a/coupon-core/src/main/java/com/laphayen/couponcore/CouponCoreConfiguration.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/CouponCoreConfiguration.java
@@ -2,7 +2,9 @@ package com.laphayen.couponcore;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @ComponentScan
 @EnableAutoConfiguration
 public class CouponCoreConfiguration {

--- a/coupon-core/src/main/java/com/laphayen/couponcore/model/BaseTimeEntity.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/model/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.laphayen.couponcore.model;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime dateCreated;
+
+    @LastModifiedDate
+    private LocalDateTime dateUpdated;
+
+
+}

--- a/coupon-core/src/main/java/com/laphayen/couponcore/model/Coupon.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/model/Coupon.java
@@ -1,0 +1,48 @@
+package com.laphayen.couponcore.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "coupons")
+public class Coupon extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private CouponType couponType;
+
+    private Integer totalQuantity;
+
+    @Column(nullable = false)
+    private int issuedQuantity;
+
+    @Column(nullable = false)
+    private int discountAmount;
+
+    @Column(nullable = false)
+    private int minAvailableAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime dateIssueStart;
+
+    @Column(nullable = false)
+    private LocalDateTime dateIssueEnd;
+
+
+}

--- a/coupon-core/src/main/java/com/laphayen/couponcore/model/CouponIssue.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/model/CouponIssue.java
@@ -1,0 +1,37 @@
+package com.laphayen.couponcore.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "coupon_issues")
+public class CouponIssue extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long couponId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime dateIssued;
+
+    private LocalDateTime dateUsed;
+
+
+}

--- a/coupon-core/src/main/java/com/laphayen/couponcore/model/CouponType.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/model/CouponType.java
@@ -1,0 +1,8 @@
+package com.laphayen.couponcore.model;
+
+public enum CouponType {
+
+    FIRST_COME_FIRST_SERVED
+
+
+}

--- a/coupon-core/src/main/resources/sql/schema.sql
+++ b/coupon-core/src/main/resources/sql/schema.sql
@@ -1,0 +1,33 @@
+CREATE TABLE `coupon`.`coupons`
+(
+    `id`                   BIGINT(20) NOT NULL AUTO_INCREMENT,
+    `title`                VARCHAR(255) NOT NULL COMMENT '쿠폰명',
+    `coupon_type`          VARCHAR(255) NOT NULL COMMENT '쿠폰 타입 (선착순 쿠폰, ..)',
+    `total_quantity`       INT NULL COMMENT '쿠폰 발급 최대 수량',
+    `issued_quantity`      INT          NOT NULL COMMENT '발급된 쿠폰 수량',
+    `discount_amount`      INT          NOT NULL COMMENT '할인 금액',
+    `min_available_amount` INT          NOT NULL COMMENT '최소 사용 금액',
+    `date_issue_start`     datetime(6) NOT NULL COMMENT '발급 시작 일시',
+    `date_issue_end`       datetime(6) NOT NULL COMMENT '발급 종료 일시',
+    `date_created`         datetime(6) NOT NULL COMMENT '생성 일시',
+    `date_updated`         datetime(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+    COMMENT '쿠폰 정책';
+
+
+CREATE TABLE `coupon`.`coupon_issues`
+(
+    `id`           BIGINT(20) NOT NULL AUTO_INCREMENT,
+    `coupon_id`    BIGINT(20) NOT NULL COMMENT '쿠폰 ID',
+    `user_id`      BIGINT(20) NOT NULL COMMENT '유저 ID',
+    `date_issued`  datetime(6) NOT NULL COMMENT '발급 일시',
+    `date_used`    datetime(6) NULL COMMENT '사용 일시',
+    `date_created` datetime(6) NOT NULL COMMENT '생성 일시',
+    `date_updated` datetime(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+    COMMENT '쿠폰 발급 내역';
+


### PR DESCRIPTION
## PR 제목

feat: 쿠폰 도메인 엔티티 및 테이블 DDL 추가

## 개요

쿠폰 발급 및 정책 관리를 위한 엔티티(Coupon, CouponIssue)와 DDL 정의, JPA Auditing 설정을 적용하였습니다.

## 주요 변경 사항
* Coupon, CouponIssue 엔티티 추가
* Coupon: 쿠폰 정책 정보 (타입, 수량, 할인 금액, 발급 기간 등)
* CouponIssue: 사용자별 쿠폰 발급/사용 내역
* CouponType enum 정의 (FIRST_COME_FIRST_SERVED)
* BaseTimeEntity 추가
* @CreatedDate, @LastModifiedDate 필드 포함
* 모든 쿠폰 엔티티에 생성/수정 시간 자동 반영
* @EnableJpaAuditing 설정 추가 (CouponCoreConfiguration)
* schema.sql 작성
* coupons, coupon_issues 테이블 정의 및 코멘트 포함

## 테스트 및 검증
* 스키마 파일 실행 후 테이블 정상 생성 확인
* @CreatedDate, @LastModifiedDate 필드가 자동으로 저장되는지 확인
* Enum 타입 필드(couponType)가 문자열로 DB에 저장되는지 확인

## 기타 사항
* 추후 쿠폰 발급 로직 및 사용 검증 로직은 별도 PR로 분리 예정
* schema.sql은 로컬 개발용으로 작성되었으며 운영 DB는 JPA 기반으로 자동 생성 가능

* * *

This closes #7 