### PR TITLE
쿠폰 부하 테스트

### DIFF
--- a/load-test/docker-compose.yml
+++ b/load-test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./:/mnt/locust
     command: >
-      -f /mnt/locust/locustfile-test.py
+      -f /mnt/locust/locustfile-issueV1.py
       --master
       -H http://host.docker.internal:8080
 
@@ -18,6 +18,6 @@ services:
     volumes:
       - ./:/mnt/locust
     command: >
-      -f /mnt/locust/locustfile-test.py
+      -f /mnt/locust/locustfile-issueV1.py
       --worker
       --master-host locust-master

--- a/load-test/locustfile-issueV1.py
+++ b/load-test/locustfile-issueV1.py
@@ -1,0 +1,15 @@
+import random
+from locust import task, FastHttpUser, stats
+
+class CouponIssueV1(FastHttpUser):
+    connection_timeout = 10.0
+    network_timeout = 10.0
+
+    @task
+    def issue(self):
+        payload = {
+            "userId" : random.randint(1, 10000000),
+            "couponId": 1,
+        }
+        with self.rest("POST", "/v1/issue", json=payload):
+            pass


### PR DESCRIPTION
## PR 제목

쿠폰 발급 API 대상 Locust 부하 테스트 시나리오 추가

## 개요

/v1/issue 엔드포인트에 대한 실질적인 부하 테스트를 수행하기 위해 Locust 테스트 시나리오를 개선하고, 마스터-워커 환경에서 테스트 스크립트를 교체하였습니다.

## 주요 변경 사항

locustfile-issueV1.py 작성
* FastHttpUser 기반 부하 테스트 클래스 CouponIssueV1 정의
* userId는 1~10,000,000 사이 랜덤, couponId는 고정값 1 사용
* POST /v1/issue 요청 반복 수행
* connection_timeout, network_timeout 각각 10초 설정

docker-compose.yml 수정
* 기존 테스트 스크립트 locustfile-test.py → locustfile-issueV1.py 로 교체
* 마스터 및 워커 모두 동일한 스크립트 참조

⸻

## 테스트 및 검증
/v1/issue 요청에 대해 총 1,058,762건 테스트 성공
95% 응답 시간: 480ms, 99% 응답 시간: 750ms
실패 응답 216건 (0.02%) 발생 — 주로 Timeout (CatchResponseError: timed out)
RPS: 평균 약 2,936, 평균 응답 시간: 334.44ms
Locust 웹 UI(8089 포트)에서 실시간 모니터링 성공

## 기타 사항

일부 타임아웃 오류는 테스트 환경 내 네트워크 부하 또는 서비스 처리 지연에 기인함
스케일링 및 병렬성 조정으로 개선 여지 있음 (worker 수 증가, 서버 thread 수 증가 등)

* * *

This closes #16 