### PR TITLE
동시성 이슈 처리

### DIFF
--- a/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
@@ -19,9 +19,8 @@ public class CouponIssueRequestService {
     private final Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     public void issueRequestV1(CouponIssueRequestDto requestDto) {
-        distributeLockExecutor.execute("lock" + requestDto.couponId(), 10000, 10000, ()  -> {
-            couponIssueService.issue(requestDto.couponId(), requestDto.userId());
-        });
+
+        couponIssueService.issue(requestDto.couponId(), requestDto.userId());
 
         log.info("쿠폰이 발급되었습니다. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
     }

--- a/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
@@ -16,7 +16,9 @@ public class CouponIssueRequestService {
     private final Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     public void issueRequestV1(CouponIssueRequestDto requestDto) {
-        couponIssueService.issue(requestDto.couponId(), requestDto.userId());
+        synchronized (this) {
+            couponIssueService.issue(requestDto.couponId(), requestDto.userId());
+        }
 
         log.info("쿠폰이 발급되었습니다. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
     }

--- a/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/laphayen/couponapi/service/CouponIssueRequestService.java
@@ -1,6 +1,7 @@
 package com.laphayen.couponapi.service;
 
 import com.laphayen.couponapi.controller.dto.CouponIssueRequestDto;
+import com.laphayen.couponcore.component.DistributeLockExecutor;
 import com.laphayen.couponcore.service.CouponIssueService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -13,12 +14,14 @@ public class CouponIssueRequestService {
 
     private final CouponIssueService couponIssueService;
 
+    private final DistributeLockExecutor distributeLockExecutor;
+
     private final Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     public void issueRequestV1(CouponIssueRequestDto requestDto) {
-        synchronized (this) {
+        distributeLockExecutor.execute("lock" + requestDto.couponId(), 10000, 10000, ()  -> {
             couponIssueService.issue(requestDto.couponId(), requestDto.userId());
-        }
+        });
 
         log.info("쿠폰이 발급되었습니다. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
     }

--- a/coupon-api/src/test/java/com/laphayen/couponapi/CouponApiApplicationTests.java
+++ b/coupon-api/src/test/java/com/laphayen/couponapi/CouponApiApplicationTests.java
@@ -2,7 +2,11 @@ package com.laphayen.couponapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.config.name=application-core")
 @SpringBootTest
 class CouponApiApplicationTests {
 

--- a/coupon-consumer/src/test/java/com/laphayen/couponconsumer/CouponConsumerApplicationTests.java
+++ b/coupon-consumer/src/test/java/com/laphayen/couponconsumer/CouponConsumerApplicationTests.java
@@ -2,7 +2,11 @@ package com.laphayen.couponconsumer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.config.name=application-core")
 @SpringBootTest
 class CouponConsumerApplicationTests {
 

--- a/coupon-core/build.gradle.kts
+++ b/coupon-core/build.gradle.kts
@@ -8,6 +8,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.redisson:redisson:3.27.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/coupon-core/src/main/java/com/laphayen/couponcore/component/DistributeLockExecutor.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/component/DistributeLockExecutor.java
@@ -1,0 +1,38 @@
+package com.laphayen.couponcore.component;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class DistributeLockExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(DistributeLockExecutor.class);
+    private final RedissonClient redissonClient;
+
+    public void execute(String lockName, long waitMilliSecond, long leaseMilliSecond, Runnable logic) {
+        RLock lock = redissonClient.getLock(lockName);
+        try {
+            boolean isLocked = lock.tryLock(waitMilliSecond, leaseMilliSecond, TimeUnit.MILLISECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("Lock 획득에 실패했습니다: " + lockName);
+            }
+            logic.run();
+        } catch (InterruptedException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+
+    }
+
+}

--- a/coupon-core/src/main/java/com/laphayen/couponcore/configuration/RedisConfiguration.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/configuration/RedisConfiguration.java
@@ -1,0 +1,26 @@
+package com.laphayen.couponcore.configuration;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        org.redisson.config.Config config = new org.redisson.config.Config();
+        String address = "redis://" + redisHost + ":" + redisPort;
+        config.useSingleServer().setAddress(address);
+        return Redisson.create(config);
+    }
+
+}

--- a/coupon-core/src/main/java/com/laphayen/couponcore/repository/mysql/CouponJpaRepository.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/repository/mysql/CouponJpaRepository.java
@@ -1,9 +1,17 @@
 package com.laphayen.couponcore.repository.mysql;
 
 import com.laphayen.couponcore.model.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :id")
+    Optional<Coupon> findCouponWithLock(long id);
 
 }

--- a/coupon-core/src/main/java/com/laphayen/couponcore/service/CouponIssueService.java
+++ b/coupon-core/src/main/java/com/laphayen/couponcore/service/CouponIssueService.java
@@ -25,7 +25,7 @@ public class CouponIssueService {
 
     @Transactional
     public void issue(long couponId, long userId) {
-        Coupon coupon = findCoupon(couponId);
+        Coupon coupon = findCouponWithLock(couponId);
         coupon.issue();
         saveCouponIssue(couponId, userId);
 
@@ -34,6 +34,12 @@ public class CouponIssueService {
     @Transactional(readOnly = true)
     public Coupon findCoupon(long couponId) {
         return couponJpaRepository.findById(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
+
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon findCouponWithLock(long couponId) {
+        return couponJpaRepository.findCouponWithLock(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
 
     }
 


### PR DESCRIPTION
## PR 제목

쿠폰 발급 로직에 Redisson 기반 분산 락 및 DB 비관적 락 적용

## 개요

고동시성 환경에서 쿠폰 발급 시 발생할 수 있는 Race Condition 문제를 해결하기 위해 Redisson 기반의 분산 락 및 JPA 비관적 락을 도입했습니다.

## 주요 변경 사항

Redisson 설정

* redisson:3.27.2 의존성 추가
* RedisConfiguration: Redis 연결 설정 (redis://{host}:{port} 형태)
* DistributeLockExecutor: tryLock() 기반의 분산 락 획득 및 실행 유틸 클래스 추가

쿠폰 발급 락 처리

* 기존 synchronized 블록 제거
* couponId 기반 Redisson 분산 락 적용 (lock_couponId)
* 락 대기 시간 및 임대 시간 각각 10초 설정
* 최종적으로 분산 락은 제거되고, DB 비관적 락 방식으로 전환

DB 비관적 락 적용
* CouponJpaRepository에 findCouponWithLock 메서드 추가 (@Lock(PESSIMISTIC_WRITE))
* CouponIssueService.issue() 메서드에서 해당 쿼리를 통해 락 획득
* 쿠폰 재고 감소의 동시성 이슈를 DB 레벨에서 제어

테스트 환경 분리
* application-core.yml 설정을 테스트에서도 사용하도록 변경
* @ActiveProfiles("test") 및 @TestPropertySource로 환경 충돌 방지

## 테스트 및 검증

로컬 및 통합 테스트 환경에서 Redis 락 적용 여부 확인
고동시성 Locust 테스트에서 Duplicate/Timeout 비율 감소 확인
DB 비관적 락 전환 이후에도 발급 정합성 유지됨

* * *

This closes #18 